### PR TITLE
Add initial state for todo

### DIFF
--- a/src/components/TodoForm.js
+++ b/src/components/TodoForm.js
@@ -6,7 +6,7 @@ export default function TodoForm() {
 
   // Creating a local state to have currently writing
   // todo item that will be sent to the global store.
-  const [todo, setTodo] = useState();
+  const [todo, setTodo] = useState("");
 
   function handleTodoChange(e) {
     setTodo(e.target.value);


### PR DESCRIPTION
React recommends controlled components to implement forms. 

> If you initially pass undefined or null as the value prop, the component starts life as an "uncontrolled" component. 

![screen shot 2018-10-29 at 22 25 23](https://user-images.githubusercontent.com/13641726/47676087-b0c03d00-dbcc-11e8-86d7-cf59abbaebb7.png)

To avoid the warning, we should define default state for todo. 